### PR TITLE
Construct RPM version field

### DIFF
--- a/.github/workflows/nnf-rpm.yml
+++ b/.github/workflows/nnf-rpm.yml
@@ -48,9 +48,26 @@ jobs:
         # file when we do this.)
         run: |
           rm -f version
+          mkdir build # so VERSION-GEN writes the version.mk file
           ./VERSION-GEN
-          awk '{print $3}' doc/version | sed -e 's/"//g;' -e 's/\-dirty$//' > version
+          echo "--- version.h begin"
+          cat build/version.h
+          echo "--- version.h end"
+          echo "--- version.mk begin"
+          cat build/version.mk
+          echo "--- version.mk end"
+          echo "--- doc/version begin"
+          cat doc/version
+          echo "--- doc/version end"
+
+          grep -E '^VERSION=' build/version.mk | awk -F= '{print $2}' > version
+
+          echo "release_tag=$(grep -E '^RELEASE_TAG=' build/version.mk | awk -F= '{print $2}')" >> $GITHUB_ENV
+          rm -rf build
+
+          echo "--- version begin"
           cat version
+          echo "--- version end"
           echo "versionDotted=$(<version)" >> $GITHUB_ENV
           echo "versionDashed=$(sed 's/\./-/g' version)" >> $GITHUB_ENV
 
@@ -101,7 +118,7 @@ jobs:
         if: startsWith(github.ref, env.STARTS_WITH_RELEASES)
         uses: tvdias/github-tagger@v0.0.1
         with:
-          tag: ${{ env.versionDotted }}
+          tag: ${{ env.release_tag }}
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: upload the release assets
         # These can be found by going to the repo's "Releases" page.
@@ -109,7 +126,7 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           name: ${{ env.versionDotted }}
-          tag_name: ${{ env.versionDotted }}
+          tag_name: ${{ env.release_tag }}
           generate_release_notes: true
           fail_on_unmatched_files: true
           files: /tmp/artifacts/*

--- a/Makefile.in
+++ b/Makefile.in
@@ -104,7 +104,7 @@ distclean: clean
 	$(Q)rm -rf config.log config.status *.lib *.exe *.so *.dll build* \
 		Makefile autom4te.cache *.tar* switchtec.spec
 
-$(OBJDIR)/version.h $(OBJDIR)/version.mk: FORCE $(OBJDIR)
+$(OBJDIR)/version.h $(OBJDIR)/version.mk: | $(OBJDIR)
 	@$(SHELL_PATH) ./VERSION-GEN
 -include $(OBJDIR)/version.mk
 
@@ -195,7 +195,7 @@ doc:
 	make -C doc
 
 .PHONY: clean compile install unintsall install-bin install-bash-completion doc
-.PHONY: FORCE dist rpm
+.PHONY: dist rpm
 
 
 -include $(patsubst %.o,%.d,$(LIB_OBJS) $(CLI_OBJS))

--- a/VERSION-GEN
+++ b/VERSION-GEN
@@ -52,25 +52,22 @@ fi
 
 VN=$(expr "$VN" : v*'\(.*\)')
 MVN=$(expr "$VN" : v*'\([0-9.]*\)')
-RVN=$(expr "$VN" : v*'[0-9.]*\-\(.*\)')
-
-# Add a "0." prefix to the release ID, but don't allow it to be doubled-up when
-# this script is called multiple times during a build.
-if [[ -n $RVN && $RVN =~ ^0 ]]
-then
-    RDVN=$(echo "$RVN" | sed -e 's/-/./g')
-elif [[ -n $RVN ]]
-then
-    RDVN=0.$(echo "$RVN" | sed -e 's/-/./g')
-else
-    RDVN="1"
-fi
+RVN=$(expr "$VN" : v*'[0-9.]*[-~]\(.*\)')
+RDVN=1
 
 # Convert a 'git describe' version to something that makes rpm versioning
 # happy:
-#    4.2-rc1-26-ge1dc405 => 4.2-0~rc1_26HPE
-#    0.5.17.g8e16 => 0.5-0~17HPE
-HPE_RDVN=$(echo "0~$RVN" | sed -e 's/\([0-9][0-9]*\)\-g.*$/\1HPE/' -e 's/\-/_/g')
+#    4.2-rc1-26-ge1dc405 => 4.2~rc1_26HPE
+#    0.5.17.g8e16 => 0.5_17HPE
+HPE_VN_1=$(echo "$RVN" | sed -e 's/\([0-9][0-9]*\)\-g.*$/\1HPE/' -e 's/\-/_/g')
+if [[ -n $HPE_VN_1 && ! $HPE_VN_1 =~ ^_ ]]
+then
+    HPE_TAG="$MVN-${HPE_VN_1}"
+    HPE_VN="$MVN~${HPE_VN_1}"
+else
+    HPE_TAG="$HPE_VN_1"
+    HPE_VN="$MVN${HPE_VN_1}"
+fi
 
 VN_RE='^([0-9]+)\.([0-9]+)(.([0-9]+))?(-rc[0-9]+)?(-([0-9]+)-g([A-Za-z0-9]+))?'
 if [[ $VN =~ $VN_RE ]]; then
@@ -102,19 +99,19 @@ if test -d $OBJDIR; then
 	fi
 
 	test "$VN" = "$VC" || {
-		echo "  VER   $VN"
-		echo "#define VERSION \"$VN\"" >$GVF
+		echo "  VER   $HPE_VN"
+		echo "#define VERSION \"$HPE_VN\"" >$GVF
 		echo "#define MAJOR $MAJOR" >>$GVF
 		echo "#define MINOR $MINOR" >>$GVF
 		echo "#define PATCH $PATCH" >>$GVF
 		echo "#define SINCE_TAG $SINCE_TAG" >>$GVF
 
-		echo "VERSION=$MVN" >$MVF
+		echo "VERSION=$HPE_VN" >$MVF
 		echo "FULL_VERSION=$VN" >>$MVF
 		echo "MAJOR_VER=$MAJOR" >>$MVF
-		echo "RELEASE_ORIG=$RDVN" >>$MVF
-		echo "RELEASE=$HPE_RDVN" >>$MVF
+		echo "RELEASE=$RDVN" >>$MVF
+		echo "RELEASE_TAG=$HPE_TAG" >>$MVF
 	}
 fi
 
-echo "PROJECT_NUMBER = \"$VN\"" > $DOCDIR/version
+echo "PROJECT_NUMBER = \"$HPE_VN\"" > $DOCDIR/version

--- a/VERSION-GEN
+++ b/VERSION-GEN
@@ -62,10 +62,10 @@ RDVN=1
 HPE_VN_1=$(echo "$RVN" | sed -e 's/\([0-9][0-9]*\)\-g.*$/\1HPE/' -e 's/\-/_/g')
 if [[ -n $HPE_VN_1 && ! $HPE_VN_1 =~ ^_ ]]
 then
-    HPE_TAG="$MVN-${HPE_VN_1}"
+    HPE_TAG="v$MVN-${HPE_VN_1}"
     HPE_VN="$MVN~${HPE_VN_1}"
 else
-    HPE_TAG="$HPE_VN_1"
+    HPE_TAG="v$HPE_VN_1"
     HPE_VN="$MVN${HPE_VN_1}"
 fi
 


### PR DESCRIPTION
Convert the git-describe into an RPM version field.
   4.2-rc1-26-ge1dc405 => 4.2~rc1_26HPE
   0.5.17.g8e16 => 0.5_17HPE

Set the RPM release field to 1.

Fix makefile looping, by using ordered prerequisite for $OBJDIR rather than the FORCE phony tag.