### PR TITLE
Add patch to invalidate the NVLOG

### DIFF
--- a/cli/main.c
+++ b/cli/main.c
@@ -1012,6 +1012,8 @@ static int log_dump(int argc, char **argv)
 		 "dump all thread info from flash in the last fatal error handling dump"},
 		{"NVHDR", SWITCHTEC_LOG_NVHDR,
 		 "dump NVLog header information in the last fatal error handling dump"},
+        {"INVNV", SWITCHTEC_LOG_INVNVLOG,
+          "Invalidate NVLOG partition in the flash to clear the last fatal error log"},
 		{}
 	};
 	const struct argconfig_choice format[] = {
@@ -1068,6 +1070,10 @@ static int log_dump(int argc, char **argv)
 				"a log defintion file. Please provide log definiton file with '-d',\n"
 				"or specify binary log format with '-f BIN' instead\n");
 		return -1;
+	} else if (cfg.type == SWITCHTEC_LOG_INVNVLOG) {
+
+        	ret = switchtec_log_invalidate(cfg.dev, cfg.type);
+		return ret;
 	}
 
 	if (cfg.format == LOG_FMT_TXT &&

--- a/inc/switchtec/switchtec.h
+++ b/inc/switchtec/switchtec.h
@@ -201,6 +201,7 @@ enum switchtec_log_type {
 	SWITCHTEC_LOG_THRD_STACK,
 	SWITCHTEC_LOG_THRD,
 	SWITCHTEC_LOG_NVHDR,
+	SWITCHTEC_LOG_INVNVLOG,
 };
 
 /**
@@ -399,6 +400,7 @@ void switchtec_perror(const char *str);
 int switchtec_log_to_file(struct switchtec_dev *dev,
 		enum switchtec_log_type type, int fd, FILE *log_def_file,
 		struct switchtec_log_file_info *info);
+int switchtec_log_invalidate(struct switchtec_dev *dev, enum switchtec_log_type type);
 int switchtec_parse_log(FILE *bin_log_file, FILE *log_def_file,
 			FILE *parsed_log_file,
 			enum switchtec_log_parse_type log_type,

--- a/lib/switchtec.c
+++ b/lib/switchtec.c
@@ -1451,6 +1451,29 @@ static int log_ram_flash_to_file(struct switchtec_dev *dev,
 }
 
 /**
+ * @brief Invalidate the NVLOG
+ * @param[in]  dev          - Switchtec device handle
+ * @param[in]  type         - Type of log data to dump
+ * @return 0 on success, error code on failure
+ */
+int switchtec_log_invalidate(struct switchtec_dev *dev, enum switchtec_log_type type)
+{
+	int ret;
+	struct log_cmd {
+		uint8_t subcmd;
+		uint8_t rsvd[3];
+	} cmd = {};
+
+	cmd.subcmd = MRPC_FWLOGRD_INVAL; 
+
+	ret = switchtec_cmd(dev, MRPC_FWLOGRD, &cmd, sizeof(cmd),
+			NULL, 0);
+	if (ret < 0)
+		return ret;
+	return 0;
+}
+
+/**
  * @brief Dump the Switchtec log data to a file
  * @param[in]  dev          - Switchtec device handle
  * @param[in]  type         - Type of log data to dump
@@ -1491,6 +1514,8 @@ int switchtec_log_to_file(struct switchtec_dev *dev,
 		return log_b_to_file(dev, MRPC_FWLOGRD_THRD, fd);
 	case SWITCHTEC_LOG_NVHDR:
 		return log_c_to_file(dev, MRPC_FWLOGRD_NVHDR, fd);
+	default:
+		return 0;
 	};
 
 	errno = EINVAL;


### PR DESCRIPTION
Patch to enable us to clear the NV logs:

```switchtec log-dump -t INVNV /dev/switchtec0```
